### PR TITLE
Fix double caracteres on input

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Vimless is a minimalist console-based text editor inspired by **nano**. It is de
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/your-username/vimless.git
+   git clone https://github.com/zewcro/vimless.git
    cd vimless
    ```
 

--- a/example.txt
+++ b/example.txt
@@ -1,0 +1,1 @@
+Ceci est un test

--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -14,9 +14,10 @@ pub fn render_text(text: &Vec<String>) -> Result<()> {
   )?;
 
   for line in text {
-      println!("{}", line); 
+      write!(io::stdout(), "{}\r\n", line)?;
   }
 
+  io::stdout().flush()?;
   Ok(())
 }
 

--- a/src/example.txt
+++ b/src/example.txt
@@ -1,2 +1,3 @@
+Ceci est un test qui semble fonctionner ! 
 
-tteerr
+


### PR DESCRIPTION
This pull request includes several changes to the `vimless` project to improve functionality and update documentation. The most important changes include modifying the `render_text` function to handle output more efficiently, updating the main loop to handle key events with modifiers, and updating the repository URL in the `README.md` file.

### Codebase improvements:

* [`src/editor/render.rs`](diffhunk://#diff-2b21ff6b1c95e20d38dccf862ca2d95a29b41f74db287c378f4d8e0b14ac5525L17-R20): Modified the `render_text` function to use `write!` instead of `println!` for better performance and added `flush` to ensure the output is written immediately.

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR5-L27): Updated the main loop to handle key events with modifiers, allowing for more complex key combinations like `Ctrl+s` for saving and `Ctrl+x` for exiting.

### Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30): Updated the repository URL to the correct one (`https://github.com/zewcro/vimless.git`).

### Example files:

* [`example.txt`](diffhunk://#diff-e7cb632359a2be17c1008b50f9ec85691cd5d66834d5fe8f63ef65ceb06682eeR1): Added a test line in French.
* [`src/example.txt`](diffhunk://#diff-d35783cfaead6f955e6a0b41b8f9476bd0806a675be6176a9423ebcee91b9dd4R1-L2): Added a more comprehensive test line in French and removed unnecessary characters.